### PR TITLE
Add a post to thread in Behat test so link to thread shows

### DIFF
--- a/features/admin.feature
+++ b/features/admin.feature
@@ -290,6 +290,9 @@ Feature: Admin
     Given threads exist:
     | thread_title      | created_by_user        | board_name        |
     | Test Moved Thread | testuser01@example.org | Test Source Board |
+    Given posts exist:
+    | content                   | created_by_user        | thread_title      | deleted |
+    | Test moved thread content | testuser01@example.org | Test Moved Thread | 0       |
     Given I am logged in as "testadmin01@example.org"
     When I am on "/admin/"
     And I follow "Boards"


### PR DESCRIPTION
This Behat test fails for me as the "Test Moved Thread" is not shown when viewing the board without the thread having a post.