### PR TITLE
Add query builder, object relationships

### DIFF
--- a/core/TCUtils.php
+++ b/core/TCUtils.php
@@ -6,7 +6,7 @@ namespace TinCan;
  * Miscellaneous helper/ utility functions.
  *
  * @package TinCan
- * @author  Dan Ruscoe <danruscoe@protonmail.com>
+ * @author  Ricky Bertram <ricky@rbwebdesigns.co.uk>
  * @license MIT https://mit-license.org/
  * @link    https://github.com/ruscoe/tincan
  */

--- a/core/TCUtils.php
+++ b/core/TCUtils.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace TinCan;
+
+/**
+ * Miscellaneous helper/ utility functions.
+ *
+ * @package TinCan
+ * @author  Dan Ruscoe <danruscoe@protonmail.com>
+ * @license MIT https://mit-license.org/
+ * @link    https://github.com/ruscoe/tincan
+ */
+class TCUtils {
+
+    /**
+     * Extract unique values from a property in a set of objects.
+     * 
+     * @param object[] Objects to extract property from
+     * @param string Property name
+     * 
+     * @return mixed[] Unique values
+     */
+    public static function get_unique_property_values(array $objects, string $property): array
+    {
+        $values = array_map(function($object) use ($property) {
+            return $object->{$property};
+        }, $objects);
+
+        return array_unique($values);
+    }
+
+}

--- a/core/db/TCDB.php
+++ b/core/db/TCDB.php
@@ -38,6 +38,15 @@ abstract class TCDB
      */
     protected $db_port;
 
+    // 1-to-1 relation, foreign_key will be in the current model.
+    public const DB_RELATION_ONE_TO_ONE = 0;
+    // 1-to-many relation defined on the parent model.
+    public const DB_RELATION_ONE_TO_MANY = 1;
+    // 1-to-many relation defined on the child model.
+    public const DB_RELATION_MANY_TO_ONE = 2;
+    // many-to-many relation - don't think any exist in TinCan right now.
+    public const DB_RELATION_MANY_TO_MANY = 3;
+
     public function __construct($db_host, $db_user, $db_pass, $db_name, $db_port)
     {
         $this->db_host = $db_host;

--- a/core/db/TCObjectQuery.php
+++ b/core/db/TCObjectQuery.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace TinCan\db;
+
+use TinCan\objects\TCObject;
+use TinCan\TCException;
+
+/**
+ * Tin Can query builder service.
+ *
+ * @package TinCan
+ * @author  Dan Ruscoe <danruscoe@protonmail.com>
+ * @license MIT https://mit-license.org/
+ * @link    https://github.com/ruscoe/tincan
+ */
+class TCObjectQuery
+{
+    private string $db_table;
+
+    private string $primary_key;
+
+    private ?array $ids = null;
+
+    private array $conditions = [];
+
+    private array $order = [];
+
+    private array $counts = [];
+
+    private int $limit = 0;
+
+    private int $offset = 0;
+
+    private TCDB $db;
+
+    private TCData $tcdata;
+
+    private TCObject $tcobject;
+
+    public function __construct(TCDB $db, TCData $tcdata, TCObject $class)
+    {
+        $this->db = $db;
+        $this->tcdata = $tcdata;
+        $this->tcobject = $class;
+        $this->db_table = $class->get_db_table();
+        $this->primary_key = $class->get_primary_key();
+    }
+
+    public function setConditions(array $conditions)
+    {
+        $this->conditions = $conditions;
+        return $this;
+    }
+
+    public function setIds(?array $ids)
+    {
+        $this->ids = $ids;
+        return $this;
+    }
+
+    public function offset(int $offset)
+    {
+        $this->offset = $offset;
+        return $this;
+    }
+
+    public function limit(int $limit)
+    {
+        $this->limit = $limit;
+        return $this;
+    }
+
+    public function setOrder(array $order)
+    {
+        $this->order = $order;
+        return $this;
+    }
+
+    public function withCount(string $relation)
+    {
+        $relations = $this->tcobject->get_db_relationships();
+        if (!key_exists($relation, $relations)) {
+            throw new TCException("Relationship $relation not found on {($this->tcobject)::class}");
+        }
+
+        $this->counts[] = $relation;
+        return $this;
+    }
+
+    public function execute()
+    {
+        $query = "SELECT {$this->getSelectExpression()} FROM `{$this->db_table}`{$this->getJoins()}";
+        
+        if (!empty($this->ids)) {
+            $ids_in = implode(',', $this->ids);
+            $query .= " WHERE `{$this->primary_key}` IN ({$ids_in})";
+        } elseif (!empty($this->conditions)) {
+            foreach ($this->conditions as $key => $condition) {
+                if (!$this->tcdata->validate_object_field($this->tcobject, $condition['field'])) {
+                    throw new TCException("Invalid field: {$condition['field']} for table {$this->db_table}");
+                }
+                $condition['field'] = str_replace('.', '`.`', $condition['field']);
+                // TODO: Allow conditions other than equals.
+                $query .= ($key === 0 ? " WHERE " : " AND ") . "`{$condition['field']}` = '{$condition['value']}'";
+            }
+        }
+
+        $query .= $this->getGroupBy();
+
+        if (!empty($this->order)) {
+            if (is_numeric(array_key_first($this->order))) {
+                $order = [];
+                foreach ($this->order as $os) {
+                    $order[] = "{$os['field']} {$os['direction']}";
+                }
+                $query .= " ORDER BY " . implode(', ', $order);
+            }
+            else {
+                $query .= " ORDER BY {$this->order['field']} {$this->order['direction']}";
+            }
+        }
+
+        if ($this->limit > 0) {
+            $query .= " LIMIT {$this->offset}, {$this->limit}";
+        }
+
+        $result = $this->db->query($query);
+
+        $objects = [];
+
+        if ($result) {
+            while ($object = $result->fetch_object()) {
+                $objects[] = new ($this->tcobject)($object);
+            }
+        }
+
+        return $objects;
+
+        // return $this->db->query($query);
+    }
+
+    private function getSelectExpression()
+    {
+        $all_relations = $this->tcobject->get_db_relationships();
+        $select = '*';
+
+        foreach ($this->counts as $relation) {
+            /** @var TCObject */
+            $tcobject = $all_relations[$relation]['class'];
+
+            $select .= ", COUNT(`{$tcobject->get_db_table()}`.`{$tcobject->get_primary_key()}`) as {$relation}_count";
+        }
+
+        return $select;
+    }
+
+    private function getJoins()
+    {
+        $all_relations = $this->tcobject->get_db_relationships();
+        $required_relations = $this->counts;
+
+        $joins = '';
+        foreach ($required_relations as $relation) {
+            /** @var TCObject */
+            $object = $all_relations[$relation]['class'];
+            $join_table = $object->get_db_table();
+            $joins = " JOIN `$join_table` ON `$join_table`.`{$this->primary_key}` = `{$this->db_table}`.`{$this->primary_key}`";
+        }
+        return $joins;
+    }
+
+    private function getGroupBy()
+    {
+        return " GROUP BY `{$this->db_table}`.`{$this->primary_key}`";
+    }
+
+}

--- a/core/db/TCObjectQuery.php
+++ b/core/db/TCObjectQuery.php
@@ -9,7 +9,7 @@ use TinCan\TCException;
  * Tin Can query builder service.
  *
  * @package TinCan
- * @author  Dan Ruscoe <danruscoe@protonmail.com>
+ * @author  Ricky Bertram <ricky@rbwebdesigns.co.uk>
  * @license MIT https://mit-license.org/
  * @link    https://github.com/ruscoe/tincan
  */

--- a/core/objects/TCAttachment.php
+++ b/core/objects/TCAttachment.php
@@ -72,4 +72,12 @@ class TCAttachment extends TCObject
             'thumbnail_file_path',
         ];
     }
+
+    /**
+     * @see   TCObject::get_db_relationships()
+     */
+    public function get_db_relationships()
+    {
+        return [];
+    }
 }

--- a/core/objects/TCBannedEmail.php
+++ b/core/objects/TCBannedEmail.php
@@ -60,4 +60,13 @@ class TCBannedEmail extends TCObject
               'email',
             ];
     }
+
+    /**
+     * @see   TCObject::get_db_relationships()
+     * @since 0.15
+     */
+    public function get_db_relationships()
+    {
+        return [];
+    }
 }

--- a/core/objects/TCBannedIp.php
+++ b/core/objects/TCBannedIp.php
@@ -60,4 +60,12 @@ class TCBannedIp extends TCObject
               'ip',
             ];
     }
+
+    /**
+     * @see   TCObject::get_db_relationships()
+     */
+    public function get_db_relationships()
+    {
+        return [];
+    }
 }

--- a/core/objects/TCBoard.php
+++ b/core/objects/TCBoard.php
@@ -2,6 +2,8 @@
 
 namespace TinCan\objects;
 
+use TinCan\db\TCDB;
+
 /**
  * Represents a forum board.
  *
@@ -116,5 +118,25 @@ class TCBoard extends TCObject
               'created_time',
               'updated_time',
             ];
+    }
+
+    /**
+     * @see   TCObject::get_db_relationships()
+     */
+    public function get_db_relationships()
+    {
+        return [
+            'threads' => [
+                'type' => TCDB::DB_RELATION_ONE_TO_MANY,
+                'class' => new TCThread,
+                'field' => 'board_id',
+            ],
+            'group' => [
+                'type' => TCDB::DB_RELATION_MANY_TO_ONE,
+                'class' => new TCBoardGroup,
+                'nullable' => false,
+                'field' => 'board_group_id',
+            ],
+        ];
     }
 }

--- a/core/objects/TCBoardGroup.php
+++ b/core/objects/TCBoardGroup.php
@@ -2,6 +2,8 @@
 
 namespace TinCan\objects;
 
+use TinCan\db\TCDB;
+
 /**
  * Represents a group of forum boards.
  *
@@ -101,5 +103,19 @@ class TCBoardGroup extends TCObject
               'created_time',
               'updated_time',
             ];
+    }
+
+    /**
+     * @see   TCObject::get_db_relationships()
+     */
+    public function get_db_relationships()
+    {
+        return [
+            'boards' => [
+                'type' => TCDB::DB_RELATION_ONE_TO_MANY,
+                'class' => new TCThread,
+                'field' => 'board_group_id',
+            ],
+        ];
     }
 }

--- a/core/objects/TCMailTemplate.php
+++ b/core/objects/TCMailTemplate.php
@@ -87,4 +87,12 @@ class TCMailTemplate extends TCObject
               'updated_time',
             ];
     }
+
+    /**
+     * @see   TCObject::get_db_relationships()
+     */
+    public function get_db_relationships()
+    {
+        return [];
+    }
 }

--- a/core/objects/TCObject.php
+++ b/core/objects/TCObject.php
@@ -19,6 +19,8 @@ abstract class TCObject
     public const ERR_NOT_SAVED = 'nosave';
     public const ERR_EMPTY_FIELD = 'empty';
 
+    protected array $counts = [];
+
     /**
      * @since 0.01
      */
@@ -64,6 +66,15 @@ abstract class TCObject
         foreach ($db_fields as $field) {
             if (isset($object->$field) && $this->validate_field_value($field, $object->$field)) {
                 $this->$field = $object->$field;
+            }
+        }
+
+        // Check for count relationship data
+        $relations = $this->get_db_relationships();
+
+        foreach (array_keys($relations) as $relation) {
+            if (isset($object->{$relation . '_count'})) {
+                $this->counts[$relation] = $object->{$relation . '_count'};
             }
         }
     }
@@ -144,4 +155,11 @@ abstract class TCObject
      * @return array the database table fields
      */
     abstract public function get_db_fields();
+
+    /**
+     * Gets the mappings between foreign keys in this object to other objects.
+     *
+     * @return array the database table relationships
+     */
+    abstract public function get_db_relationships();
 }

--- a/core/objects/TCPage.php
+++ b/core/objects/TCPage.php
@@ -101,4 +101,13 @@ class TCPage extends TCObject
               'required',
             ];
     }
+
+    /**
+     * @see   TCObject::get_db_relationships()
+     * @since 0.15
+     */
+    public function get_db_relationships()
+    {
+        return [];
+    }
 }

--- a/core/objects/TCPendingUser.php
+++ b/core/objects/TCPendingUser.php
@@ -95,4 +95,12 @@ class TCPendingUser extends TCObject
               'confirmation_code',
             ];
     }
+
+    /**
+     * @see   TCObject::get_db_relationships()
+     */
+    public function get_db_relationships()
+    {
+        return [];
+    }
 }

--- a/core/objects/TCPost.php
+++ b/core/objects/TCPost.php
@@ -2,6 +2,8 @@
 
 namespace TinCan\objects;
 
+use TinCan\db\TCDB;
+
 /**
  * Represents a forum post.
  *
@@ -144,5 +146,26 @@ class TCPost extends TCObject
               'updated_by_user',
               'deleted',
             ];
+    }
+
+    /**
+     * @see   TCObject::get_db_relationships()
+     */
+    public function get_db_relationships()
+    {
+        return [
+            'thread' => [
+                'type' => TCDB::DB_RELATION_MANY_TO_ONE,
+                'nullable' => false,
+                'class' => new TCThread,
+                'field' => 'thread_id',
+            ],
+            'user' => [
+                'type' => TCDB::DB_RELATION_MANY_TO_ONE,
+                'nullable' => false,
+                'class' => new TCUser,
+                'field' => 'user_id',
+            ],
+        ];
     }
 }

--- a/core/objects/TCReport.php
+++ b/core/objects/TCReport.php
@@ -84,4 +84,12 @@ class TCReport extends TCObject
             'updated_time',
         ];
     }
+
+    /**
+     * @see   TCObject::get_db_relationships()
+     */
+    public function get_db_relationships()
+    {
+        return [];
+    }
 }

--- a/core/objects/TCRole.php
+++ b/core/objects/TCRole.php
@@ -79,4 +79,12 @@ class TCRole extends TCObject
               'allowed_actions',
             ];
     }
+
+    /**
+     * @see   TCObject::get_db_relationships()
+     */
+    public function get_db_relationships()
+    {
+        return [];
+    }
 }

--- a/core/objects/TCSession.php
+++ b/core/objects/TCSession.php
@@ -101,4 +101,12 @@ class TCSession extends TCObject
               'expiration_time',
             ];
     }
+
+    /**
+     * @see   TCObject::get_db_relationships()
+     */
+    public function get_db_relationships()
+    {
+        return [];
+    }
 }

--- a/core/objects/TCSetting.php
+++ b/core/objects/TCSetting.php
@@ -102,4 +102,12 @@ class TCSetting extends TCObject
               'required',
             ];
     }
+
+    /**
+     * @see   TCObject::get_db_relationships()
+     */
+    public function get_db_relationships()
+    {
+        return [];
+    }
 }

--- a/core/objects/TCThread.php
+++ b/core/objects/TCThread.php
@@ -2,6 +2,8 @@
 
 namespace TinCan\objects;
 
+use TinCan\db\TCDB;
+
 /**
  * Represents a forum thread.
  *
@@ -154,16 +156,54 @@ class TCThread extends TCObject
     public function get_db_fields()
     {
         return [
-              'board_id',
-              'thread_title',
-              'first_post_id',
-              'created_by_user',
-              'updated_by_user',
-              'created_time',
-              'updated_time',
-              'deleted',
-              'pinned',
-              'locked',
-            ];
+            'board_id',
+            'thread_title',
+            'first_post_id',
+            'created_by_user',
+            'updated_by_user',
+            'created_time',
+            'updated_time',
+            'deleted',
+            'pinned',
+            'locked',
+        ];
+    }
+
+    /**
+     * @see   TCObject::get_db_relationships()
+     */
+    public function get_db_relationships()
+    {
+        return [
+            'board' => [
+                'type' => TCDB::DB_RELATION_MANY_TO_ONE,
+                'nullable' => false,
+                'field' => 'board_id',
+                'class' => new TCBoard,
+            ],
+            'posts' => [
+                'type' => TCDB::DB_RELATION_ONE_TO_MANY,
+                'field' => 'thread_id',
+                'class' => new TCPost,
+            ],
+            'first_post' => [
+                'type' => TCDB::DB_RELATION_ONE_TO_ONE,
+                'nullable' => false,
+                'field' => 'first_post_id',
+                'class' => new TCPost,
+            ],
+            'created_by_user' => [
+                'type' => TCDB::DB_RELATION_ONE_TO_ONE,
+                'nullable' => false,
+                'field' => 'created_by_user',
+                'class' => new TCUser,
+            ],
+            'updated_by_user' => [
+                'type' => TCDB::DB_RELATION_ONE_TO_ONE,
+                'nullable' => false,
+                'field' => 'updated_by_user',
+                'class' => new TCUser,
+            ],
+        ];
     }
 }

--- a/core/objects/TCUser.php
+++ b/core/objects/TCUser.php
@@ -2,6 +2,8 @@
 
 namespace TinCan\objects;
 
+use TinCan\db\TCDB;
+
 /**
  * Represents a forum user.
  *
@@ -393,8 +395,7 @@ class TCUser extends TCObject
      */
     public function validate_email($email)
     {
-        // TODO: Validate email format.
-        if (empty($email)) {
+        if (filter_var($email, FILTER_VALIDATE_EMAIL) === false) {
             return false;
         }
 
@@ -474,5 +475,24 @@ class TCUser extends TCObject
               'created_time',
               'updated_time',
             ];
+    }
+
+    /**
+     * @see   TCObject::get_db_relationships()
+     */
+    public function get_db_relationships()
+    {
+        return [
+            'posts' => [
+                'type' => TCDB::DB_RELATION_ONE_TO_MANY,
+                'class' => new TCPost,
+                'field' => 'user_id',
+            ],
+            'created_threads' => [
+                'type' => TCDB::DB_RELATION_ONE_TO_MANY,
+                'class' => new TCThread,
+                'field' => 'created_by_user',
+            ],
+        ];
     }
 }

--- a/core/template/TCURL.php
+++ b/core/template/TCURL.php
@@ -36,6 +36,9 @@ class TCURL
             $url .= 'index.php?page='.$page;
 
             foreach ($params as $name => $value) {
+                if (empty($value)) {
+                    continue;
+                }
                 $url .= '&'.$name.'='.urlencode($value);
             }
         }
@@ -63,6 +66,9 @@ class TCURL
             $url .= 'index.php?page='.$page;
 
             foreach ($params as $name => $value) {
+                if (empty($value)) {
+                    continue;
+                }
                 $url .= '&'.$name.'='.urlencode($value);
             }
         }

--- a/themes/tincan/templates/thread-preview.php
+++ b/themes/tincan/templates/thread-preview.php
@@ -12,11 +12,12 @@ use TinCan\template\TCURL;
 $user = $data['user'];
 $thread = $data['thread'];
 $settings = $data['settings'];
+$count = $data['post_count'];
 
 $user_url = TCURL::create_url($settings['page_user'], ['user' => $user->user_id]);
 ?>
 
 <div id="thread-<?php echo $thread->thread_id; ?>" class="thread-preview">
   <h2 class="section-subheader"><a href="<?php echo $data['url']; ?>"><?php echo $thread->thread_title; ?></a></h2>
-  <span class="thread-meta last-post-date">Last post by <a href="<?php echo $user_url; ?>"><?php echo $user->username; ?></a> at <?php echo $data['last_post_date']; ?></span>
+  <span><?php echo $count; ?> posts</span>,<span class="thread-meta last-post-date">Last post by <a href="<?php echo $user_url; ?>"><?php echo $user->username; ?></a> at <?php echo $data['last_post_date']; ?></span>
 </div>


### PR DESCRIPTION
Added class `TCObjectQuery` which gives OO way to build SELECT queries to fetch TCObjects.

Added a new abstract function to TCObject `get_db_relationships` for extending classes to define their relations. This allows posts to be counted for each thread in one query for example (see `themes/tincan/templates/page/board.php`)